### PR TITLE
Fix concurrency safe due to shared atI18n object

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ func main() {
   router.Use(ginI18n.Localize())
 
   router.GET("/", func(context *gin.Context) {
-    context.String(http.StatusOK, ginI18n.MustGetMessage("welcome"))
+    context.String(http.StatusOK, ginI18n.MustGetMessage(context, "welcome"))
   })
 
   router.GET("/:name", func(context *gin.Context) {
-    context.String(http.StatusOK, ginI18n.MustGetMessage(&i18n.LocalizeConfig{
+    context.String(http.StatusOK, ginI18n.MustGetMessage(context, &i18n.LocalizeConfig{
       MessageID: "welcomeWithName",
       TemplateData: map[string]string{
         "name": context.Param("name"),
@@ -92,11 +92,11 @@ func main() {
   })))
 
   router.GET("/", func(context *gin.Context) {
-    context.String(http.StatusOK, ginI18n.MustGetMessage("welcome"))
+    context.String(http.StatusOK, ginI18n.MustGetMessage(context, "welcome"))
   })
 
   router.GET("/:name", func(context *gin.Context) {
-    context.String(http.StatusOK, ginI18n.MustGetMessage(&i18n.LocalizeConfig{
+    context.String(http.StatusOK, ginI18n.MustGetMessage(context, &i18n.LocalizeConfig{
       MessageID: "welcomeWithName",
       TemplateData: map[string]string{
         "name": context.Param("name"),
@@ -143,11 +143,11 @@ func main() {
   ))
 
   router.GET("/", func(context *gin.Context) {
-    context.String(http.StatusOK, ginI18n.MustGetMessage("welcome"))
+    context.String(http.StatusOK, ginI18n.MustGetMessage(context, "welcome"))
   })
 
   router.GET("/:name", func(context *gin.Context) {
-    context.String(http.StatusOK, ginI18n.MustGetMessage(&i18n.LocalizeConfig{
+    context.String(http.StatusOK, ginI18n.MustGetMessage(context, &i18n.LocalizeConfig{
       MessageID: "welcomeWithName",
       TemplateData: map[string]string{
         "name": context.Param("name"),

--- a/_example/main.go
+++ b/_example/main.go
@@ -18,11 +18,11 @@ func main() {
 	router.Use(ginI18n.Localize())
 
 	router.GET("/", func(context *gin.Context) {
-		context.String(http.StatusOK, ginI18n.MustGetMessage("welcome"))
+		context.String(http.StatusOK, ginI18n.MustGetMessage(context, "welcome"))
 	})
 
 	router.GET("/:name", func(context *gin.Context) {
-		context.String(http.StatusOK, ginI18n.MustGetMessage(&i18n.LocalizeConfig{
+		context.String(http.StatusOK, ginI18n.MustGetMessage(context, &i18n.LocalizeConfig{
 			MessageID: "welcomeWithName",
 			TemplateData: map[string]string{
 				"name": context.Param("name"),

--- a/i18n.go
+++ b/i18n.go
@@ -4,10 +4,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-var atI18n GinI18n
-
 // newI18n ...
-func newI18n(opts ...Option) {
+func newI18n(opts ...Option) GinI18n {
 	// init ins
 	ins := &ginI18nImpl{}
 
@@ -26,43 +24,50 @@ func newI18n(opts ...Option) {
 		ins.getLngHandler = defaultGetLngHandler
 	}
 
-	atI18n = ins
+	return ins
 }
 
 // Localize ...
 func Localize(opts ...Option) gin.HandlerFunc {
-	newI18n(opts...)
+	atI18n := newI18n(opts...)
 	return func(context *gin.Context) {
+		context.Set("i18n", atI18n)
 		atI18n.setCurrentContext(context)
 	}
 }
 
-/*GetMessage get the i18n message
- param is one of these type: messageID, *i18n.LocalizeConfig
- Example:
-	GetMessage("hello") // messageID is hello
-	GetMessage(&i18n.LocalizeConfig{
-			MessageID: "welcomeWithName",
-			TemplateData: map[string]string{
-				"name": context.Param("name"),
-			},
-	})
+/*
+GetMessage get the i18n message
+
+	 param is one of these type: messageID, *i18n.LocalizeConfig
+	 Example:
+		GetMessage("hello") // messageID is hello
+		GetMessage(&i18n.LocalizeConfig{
+				MessageID: "welcomeWithName",
+				TemplateData: map[string]string{
+					"name": context.Param("name"),
+				},
+		})
 */
-func GetMessage(param interface{}) (string, error) {
+func GetMessage(context *gin.Context, param interface{}) (string, error) {
+	atI18n := context.MustGet("i18n").(GinI18n)
 	return atI18n.getMessage(param)
 }
 
-/*MustGetMessage get the i18n message without error handling
-  param is one of these type: messageID, *i18n.LocalizeConfig
-  Example:
-	MustGetMessage("hello") // messageID is hello
-	MustGetMessage(&i18n.LocalizeConfig{
-			MessageID: "welcomeWithName",
-			TemplateData: map[string]string{
-				"name": context.Param("name"),
-			},
-	})
+/*
+MustGetMessage get the i18n message without error handling
+
+	  param is one of these type: messageID, *i18n.LocalizeConfig
+	  Example:
+		MustGetMessage("hello") // messageID is hello
+		MustGetMessage(&i18n.LocalizeConfig{
+				MessageID: "welcomeWithName",
+				TemplateData: map[string]string{
+					"name": context.Param("name"),
+				},
+		})
 */
-func MustGetMessage(param interface{}) string {
+func MustGetMessage(context *gin.Context, param interface{}) string {
+	atI18n := context.MustGet("i18n").(GinI18n)
 	return atI18n.mustGetMessage(param)
 }

--- a/i18n.go
+++ b/i18n.go
@@ -41,8 +41,8 @@ GetMessage get the i18n message
 
 	 param is one of these type: messageID, *i18n.LocalizeConfig
 	 Example:
-		GetMessage("hello") // messageID is hello
-		GetMessage(&i18n.LocalizeConfig{
+		GetMessage(context, "hello") // messageID is hello
+		GetMessage(context, &i18n.LocalizeConfig{
 				MessageID: "welcomeWithName",
 				TemplateData: map[string]string{
 					"name": context.Param("name"),
@@ -59,8 +59,8 @@ MustGetMessage get the i18n message without error handling
 
 	  param is one of these type: messageID, *i18n.LocalizeConfig
 	  Example:
-		MustGetMessage("hello") // messageID is hello
-		MustGetMessage(&i18n.LocalizeConfig{
+		MustGetMessage(context, "hello") // messageID is hello
+		MustGetMessage(context, &i18n.LocalizeConfig{
 				MessageID: "welcomeWithName",
 				TemplateData: map[string]string{
 					"name": context.Param("name"),


### PR DESCRIPTION
In terms of the https://github.com/gin-contrib/i18n/issues/21 issue, the middleware is not concurrency safe due to using atI18n variable at global scope. It would be critical to run in the production which handle many concurrency requests. So I propose to fix it by storing atI18n variable in gin.Context. However, the change would be made a break change in the signatures of GetMessage and MustGetMessage function