### PR TITLE
fix the filepath problem on windows

### DIFF
--- a/ginI18n.go
+++ b/ginI18n.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"github.com/gin-gonic/gin"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
@@ -67,7 +67,7 @@ func (i *ginI18nImpl) setGetLngHandler(handler GetLngHandler) {
 // loadMessageFiles load all file localize to bundle
 func (i *ginI18nImpl) loadMessageFiles(config *BundleCfg) {
 	for _, lng := range config.AcceptLanguage {
-		path := filepath.Join(config.RootPath, lng.String()) + "." + config.FormatBundleFile
+		path := path.Join(config.RootPath, lng.String()) + "." + config.FormatBundleFile
 		if err := i.loadMessageFile(config, path); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
From [documentation of embed](https://pkg.go.dev/embed), it clearly says The path separator is a forward slash, even on Windows systems.And the result on windows got from the filepath.Join() function will use '\\' but '/',so if we use it on windows, it will panic because can't find the file