### PR TITLE
Mark GinI18n recievers as public

### DIFF
--- a/ginI18n.go
+++ b/ginI18n.go
@@ -20,7 +20,7 @@ type ginI18nImpl struct {
 }
 
 // getMessage get localize message by lng and messageID
-func (i *ginI18nImpl) getMessage(ctx *gin.Context, param interface{}) (string, error) {
+func (i *ginI18nImpl) GetMessage(ctx *gin.Context, param interface{}) (string, error) {
 	lng := i.getLngHandler(ctx, i.defaultLanguage.String())
 	localizer := i.getLocalizerByLng(lng)
 
@@ -38,12 +38,12 @@ func (i *ginI18nImpl) getMessage(ctx *gin.Context, param interface{}) (string, e
 }
 
 // mustGetMessage ...
-func (i *ginI18nImpl) mustGetMessage(ctx *gin.Context, param interface{}) string {
-	message, _ := i.getMessage(ctx, param)
+func (i *ginI18nImpl) MustGetMessage(ctx *gin.Context, param interface{}) string {
+	message, _ := i.GetMessage(ctx, param)
 	return message
 }
 
-func (i *ginI18nImpl) setBundle(cfg *BundleCfg) {
+func (i *ginI18nImpl) SetBundle(cfg *BundleCfg) {
 	bundle := i18n.NewBundle(cfg.DefaultLanguage)
 	bundle.RegisterUnmarshalFunc(cfg.FormatBundleFile, cfg.UnmarshalFunc)
 
@@ -54,7 +54,7 @@ func (i *ginI18nImpl) setBundle(cfg *BundleCfg) {
 	i.setLocalizerByLng(cfg.AcceptLanguage)
 }
 
-func (i *ginI18nImpl) setGetLngHandler(handler GetLngHandler) {
+func (i *ginI18nImpl) SetGetLngHandler(handler GetLngHandler) {
 	i.getLngHandler = handler
 }
 

--- a/i18n.go
+++ b/i18n.go
@@ -16,7 +16,7 @@ func newI18n(opts ...Option) GinI18n {
 
 	// 	if bundle isn't constructed then assign it from default
 	if ins.bundle == nil {
-		ins.setBundle(defaultBundleConfig)
+		ins.SetBundle(defaultBundleConfig)
 	}
 
 	// if getLngHandler isn't constructed then assign it from default
@@ -48,7 +48,7 @@ func Localize(opts ...Option) gin.HandlerFunc {
 //	})
 func GetMessage(context *gin.Context, param interface{}) (string, error) {
 	atI18n := context.Value("i18n").(GinI18n)
-	return atI18n.getMessage(context, param)
+	return atI18n.GetMessage(context, param)
 }
 
 // MustGetMessage get the i18n message without error handling
@@ -64,5 +64,5 @@ func GetMessage(context *gin.Context, param interface{}) (string, error) {
 //	})
 func MustGetMessage(context *gin.Context, param interface{}) string {
 	atI18n := context.MustGet("i18n").(GinI18n)
-	return atI18n.mustGetMessage(context, param)
+	return atI18n.MustGetMessage(context, param)
 }

--- a/interface.go
+++ b/interface.go
@@ -6,8 +6,8 @@ import (
 
 // GinI18n ...
 type GinI18n interface {
-	getMessage(context *gin.Context, param interface{}) (string, error)
-	mustGetMessage(context *gin.Context, param interface{}) string
-	setBundle(cfg *BundleCfg)
-	setGetLngHandler(handler GetLngHandler)
+	GetMessage(context *gin.Context, param interface{}) (string, error)
+	MustGetMessage(context *gin.Context, param interface{}) string
+	SetBundle(cfg *BundleCfg)
+	SetGetLngHandler(handler GetLngHandler)
 }

--- a/option.go
+++ b/option.go
@@ -30,7 +30,7 @@ func WithBundle(config *BundleCfg) Option {
 		if config.Loader == nil {
 			config.Loader = defaultLoader
 		}
-		g.setBundle(config)
+		g.SetBundle(config)
 	}
 }
 
@@ -39,6 +39,6 @@ func WithBundle(config *BundleCfg) Option {
 // This option allows you to customize how the current language is determined.
 func WithGetLngHandle(handler GetLngHandler) Option {
 	return func(g GinI18n) {
-		g.setGetLngHandler(handler)
+		g.SetGetLngHandler(handler)
 	}
 }


### PR DESCRIPTION
## Why?

For testing, users could mock `GinI18n` implementation, but they cannot do.

```go
c, _ := gin.CreateTestContext(httptest.NewRecorder())
c.Set("i18n", &mockedGinI18N{})

if i18n.MustGetMessage(c, "hello_world") != "hello world" {
    t.Fatal()
}
```

However, the `GinI18n` interface defines 4 receivers:

```go
getMessage(context *gin.Context, param interface{}) (string, error)
mustGetMessage(context *gin.Context, param interface{}) string
setBundle(cfg *BundleCfg)
setGetLngHandler(handler GetLngHandler)
```

Users cannot define `mockedGinI18N` in their code, because `GinI18n` has  non-exported method.

## How?

In this PR, I fixed that `GinI18n` interface receivers with public.